### PR TITLE
Fix liblo ignoring CMake variables

### DIFF
--- a/liblo/all/conanfile.py
+++ b/liblo/all/conanfile.py
@@ -18,10 +18,10 @@ class libloConan(ConanFile):
 
     def generate(self):
         tc = CMakeToolchain(self)
-        tc.variables["WITH_TOOLS"] = "OFF"
-        tc.variables["WITH_TESTS"] = "OFF"
-        tc.variables["WITH_EXAMPLES"] = "OFF"
-        tc.variables["WITH_CPP_TESTS"] = "OFF"
+        tc.cache_variables["WITH_TOOLS"] = "OFF"
+        tc.cache_variables["WITH_TESTS"] = "OFF"
+        tc.cache_variables["WITH_EXAMPLES"] = "OFF"
+        tc.cache_variables["WITH_CPP_TESTS"] = "OFF"
         tc.generate()
 
     def build(self):


### PR DESCRIPTION
Conan ignores CMake fields that are marked as CACHE when passed via `variables`, which is the case for liblo. In these cases, `cache_variables` should be used instead.