### PR TITLE
Package Fcitx5 Qt plugin

### DIFF
--- a/fcitx5-qt/all/conandata.yml
+++ b/fcitx5-qt/all/conandata.yml
@@ -1,0 +1,7 @@
+sources:
+  5.1.13:
+    url: "https://github.com/fcitx/fcitx5-qt/archive/refs/tags/5.1.13.tar.gz"
+    sha256: "74b2c43ca865ec9ede257bcd3bdadafc20f571900cb2440a4488335e4d4e91cc"
+patches:
+  5.1.13:
+    - "patch_file": "patches/Fix_private_Qt_Gui_usage.patch"

--- a/fcitx5-qt/all/conanfile.py
+++ b/fcitx5-qt/all/conanfile.py
@@ -1,0 +1,88 @@
+import os
+from conan import ConanFile
+from conan.tools.files import collect_libs, copy, get, apply_conandata_patches, export_conandata_patches
+from conan.tools.scm import Version
+from conan.tools.cmake import CMakeToolchain, CMake, cmake_layout, CMakeDeps
+
+class WAPConan(ConanFile):
+    name = "fcitx5-qt"
+    package_type = "shared-library"
+    license = "Mixed LGPL2.1+ and BSD"
+    url = "https://github.com/fcitx/fcitx5-qt"
+    description = "fcitx5-qt is the Qt im-module for fcitx5 and it's needed to use fcitx5 with Qt-based applications."
+    settings = "os", "compiler", "build_type", "arch"
+    options = {
+        "ENABLE_QT5": [True, False],
+        "ENABLE_QT6": [True, False],
+        "ENABLE_X11": [True, False],
+        "BUILD_ONLY_PLUGIN": [True, False],
+        "BUILD_STATIC_PLUGIN": [True, False],
+        "WITH_FCITX_PLUGIN_NAME": [True, False],
+        "ENABLE_QT6_WAYLAND_WORKAROUND": [True, False]
+    }
+    default_options = {
+        "ENABLE_QT5": True,
+        "ENABLE_QT6": False,
+        "ENABLE_X11": True,
+        "BUILD_ONLY_PLUGIN": True,
+        "BUILD_STATIC_PLUGIN": False,
+        "WITH_FCITX_PLUGIN_NAME": True,
+        "ENABLE_QT6_WAYLAND_WORKAROUND": True
+    }
+
+    def layout(self):
+        cmake_layout(self)
+
+    def export_sources(self):
+        # *Copy* patches into source.
+        export_conandata_patches(self)
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+        # Apply previously copied patches.
+        apply_conandata_patches(self)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        #tc.cache_variables["BUILD_SHARED"] = self.options.shared
+        tc.cache_variables["ENABLE_QT5"] = self.options.ENABLE_QT5
+        tc.cache_variables["ENABLE_QT6"] = self.options.ENABLE_QT6
+        tc.cache_variables["ENABLE_X11"] = self.options.ENABLE_X11
+        tc.cache_variables["BUILD_ONLY_PLUGIN"] = self.options.BUILD_ONLY_PLUGIN
+        tc.cache_variables["BUILD_STATIC_PLUGIN"] = self.options.BUILD_STATIC_PLUGIN
+        tc.cache_variables["WITH_FCITX_PLUGIN_NAME"] = self.options.WITH_FCITX_PLUGIN_NAME
+        tc.cache_variables["ENABLE_QT6_WAYLAND_WORKAROUND"] = self.options.ENABLE_QT6_WAYLAND_WORKAROUND
+        tc.cache_variables["CMAKE_INSTALL_QT5PLUGINDIR"] = os.path.join(self.package_folder, "lib")
+        tc.cache_variables["CMAKE_INSTALL_QT6PLUGINDIR"] = os.path.join(self.package_folder, "lib")
+        tc.generate()
+        deps = CMakeDeps(self)
+        deps.generate()
+
+    def requirements(self):
+        if self.options.ENABLE_QT5:
+            #self.requires("qt/5.15.18")  # We override this in Overte's conanfile.py
+            self.requires("qt/5.15.2@overte/system")
+            #self.requires("qt/5.15.18@overte/experimental#3a9079f3023351a7319be352cc6f4665")
+        if self.options.ENABLE_QT6:
+            self.requires("qt/6.11.1")  # We override this in Overte's conanfile.py
+        if self.options.ENABLE_X11:
+            self.requires("xorg/system")
+        if not self.options.BUILD_ONLY_PLUGIN:  # TODO: Looks like this adds translations for the plugin?
+            self.requires("Fcitx5Utils")
+
+    def build_requirements(self):
+        self.tool_requires("extra-cmake-modules/6.8.0")
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(self, "*", src=os.path.join(self.source_folder + "LICENSES"), dst=os.path.join(self.package_folder, "licenses")) # FIXME: This doesn't work and I have no idea why.
+        copy(self, "README.md", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
+        cmake.install()
+
+    def package_info(self):
+        self.cpp_info.libs = collect_libs(self)

--- a/fcitx5-qt/all/patches/Fix_private_Qt_Gui_usage.patch
+++ b/fcitx5-qt/all/patches/Fix_private_Qt_Gui_usage.patch
@@ -1,0 +1,15 @@
+# fcitx5-qt/qt5/platforminputcontext/main.h uses `QPlatformInputContextFactoryInterface_iid` which is private in Qt Gui.
+# On most systems, just having the private headers installed is enough; When building with a Conan Qt source package it will behave as if it isn't installed without explicitly targetting it.
+# This is the way it behaves otherwise: https://github.com/fcitx/fcitx5-qt/issues/2#issuecomment-550573433
+diff --git a/qt5/platforminputcontext/CMakeLists.txt b/qt5/platforminputcontext/CMakeLists.txt
+index c461f4e..b4b16fe 100644
+--- a/qt5/platforminputcontext/CMakeLists.txt
++++ b/qt5/platforminputcontext/CMakeLists.txt
+@@ -42,6 +42,7 @@ endif()
+ target_link_libraries(fcitx5platforminputcontextplugin
+                           Qt5::Core
+                           Qt5::Gui
++                          Qt5::GuiPrivate
+                           Qt5::DBus
+                           Qt5::Widgets
+                           Fcitx5Qt5::DBusAddons


### PR DESCRIPTION
This PR adds a new recipe for building fcitx5-qt, which is the plugin required for Fcitx support on Linux, which means it is required by most IME users on Linux.
On system Qt we can just depend on the fcitx5-qt system package, but when building Qt from source we also need to build fcitx5-qt from source.